### PR TITLE
98953 - Don't log exceptions when JsonConvert.DeserializeObject throw JsonReaderException

### DIFF
--- a/src/Equinor.ProCoSys.Config/CommWebApp/Configuration.cs
+++ b/src/Equinor.ProCoSys.Config/CommWebApp/Configuration.cs
@@ -79,10 +79,15 @@ namespace Equinor.ProCoSys.Config.CommWebApp
                     object parsedConfig = JsonConvert.DeserializeObject(item.Value);
                     configSet.Configuration.Add(item.Key, parsedConfig);
                 }
+                catch (JsonReaderException)
+                {
+                    // Value is not a valid JSON. Falling back to adding RAW value to output config for key.
+                    // When this is a plain value, like a number or string, its expected
+                    configSet.Configuration.Add(item.Key, item.Value);
+                }
                 catch (Exception e)
                 {
-                    log.LogWarning(e,$"Failed to format JSON for config key: {item.Key}. If this is a plain value, like a number or string, its expected", item);
-                    log.LogInformation(e,$"Falling back to adding RAW value to output config for key: {item.Key}", item);
+                    log.LogError(e, $"Failed to format JSON for config key: {item.Key}. Falling back to adding RAW value to output");
                     configSet.Configuration.Add(item.Key, item.Value);
                 }
             }

--- a/src/Equinor.ProCoSys.Config/MCWebapp/Configuration.cs
+++ b/src/Equinor.ProCoSys.Config/MCWebapp/Configuration.cs
@@ -79,10 +79,15 @@ namespace Equinor.ProCoSys.Config.MCWebApp
                     object parsedConfig = JsonConvert.DeserializeObject(item.Value);
                     configSet.Configuration.Add(item.Key, parsedConfig);
                 }
+                catch (JsonReaderException)
+                {
+                    // Value is not a valid JSON. Falling back to adding RAW value to output config for key.
+                    // When this is a plain value, like a number or string, its expected
+                    configSet.Configuration.Add(item.Key, item.Value);
+                }
                 catch (Exception e)
                 {
-                    log.LogWarning(e,$"Failed to format JSON for config key: {item.Key}. If this is a plain value, like a number or string, its expected", item);
-                    log.LogInformation(e,$"Falling back to adding RAW value to output config for key: {item.Key}", item);
+                    log.LogError(e, $"Failed to format JSON for config key: {item.Key}. Falling back to adding RAW value to output");
                     configSet.Configuration.Add(item.Key, item.Value);
                 }
             }

--- a/src/Equinor.ProCoSys.Config/ProcosysJsFrontend/FrontendConfiguration.cs
+++ b/src/Equinor.ProCoSys.Config/ProcosysJsFrontend/FrontendConfiguration.cs
@@ -79,10 +79,15 @@ namespace Equinor.ProCoSys.Config.ProcosysJsFrontend
                     object parsedConfig = JsonConvert.DeserializeObject(item.Value);
                     configSet.Configuration.Add(item.Key, parsedConfig);
                 }
+                catch (JsonReaderException)
+                {
+                    // Value is not a valid JSON. Falling back to adding RAW value to output config for key.
+                    // When this is a plain value, like a number or string, its expected
+                    configSet.Configuration.Add(item.Key, item.Value);
+                }
                 catch (Exception e)
                 {
-                    log.LogWarning(e,$"Failed to format JSON for config key: {item.Key}. If this is a plain value, like a number or string, its expected", item);
-                    log.LogInformation(e,$"Falling back to adding RAW value to output config for key: {item.Key}", item);
+                    log.LogError(e,$"Failed to format JSON for config key: {item.Key}. Falling back to adding RAW value to output");
                     configSet.Configuration.Add(item.Key, item.Value);
                 }
             }


### PR DESCRIPTION
It is an OK condition since some configs are JSON, other are plain text.

[AB#98953](https://statoildeveloper.visualstudio.com/b6d97460-2e53-47ae-aad4-b41396d90828/_workitems/edit/98953)